### PR TITLE
Add dlstatus operation 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    faxage (1.2.1)
+    faxage (1.2.2)
       httparty
 
 GEM

--- a/lib/faxage/version.rb
+++ b/lib/faxage/version.rb
@@ -1,3 +1,3 @@
 module Faxage
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end


### PR DESCRIPTION
The `dlstatus` operation allows you to pull down a .tiff or .pdf (this gem's proposed default) of a sent fax image if you supply the `job_id`. 

I added this to the `InformationGathering` class because it made more sense to me than the `SendFax` class, but I'm open to other ideas (a new class?)