### PR TITLE
Added support to filter by datetime for listfax using the "begin" option

### DIFF
--- a/lib/faxage/receive_fax.rb
+++ b/lib/faxage/receive_fax.rb
@@ -54,12 +54,15 @@ module Faxage
 
       subdirectory = "/httpsfax.php"
 
+      # Disregard the "begin" option flags and don't set it to 1. We can use this
+      # flag to retrieve all faxes that was received since timestamp X where
+      # X has the format of %Y-%m-%d %H:%M:%S.
       body = {
         operation: "listfax",
         username: username,
         company: company,
         password: password
-      }.merge!(options.each { |k, v| options[k] = 1 if v } )
+      }.merge!(options.each { |k, v| options[k] = 1 if v and !(k == "begin" or k == :begin) })
 
       response = self.class.post(subdirectory,
         body: body

--- a/lib/faxage/receive_fax.rb
+++ b/lib/faxage/receive_fax.rb
@@ -62,7 +62,7 @@ module Faxage
         username: username,
         company: company,
         password: password
-      }.merge!(options.each { |k, v| options[k] = 1 if v and !(k == "begin" or k == :begin) })
+      }.merge!(options.each { |k, v| options[k] = 1 if v and !([:begin, :didnumber].include?(k.to_sym)) })
 
       response = self.class.post(subdirectory,
         body: body


### PR DESCRIPTION
## What's Included 

The `begin` option for `listfax` currently gets set to 1 by default. This prevents anyone from using `begin` to filter the received faxes by timestamp. I made a minor modification so that the `begin` option gets handled accordingly for the `listfax` operation.